### PR TITLE
#855 return array to avoid PHP 7.2 error

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -326,7 +326,7 @@ function sell_media_get_attachments( $post_id ) {
 	if ( is_array( $meta ) ) {
 		return $meta;
 	}
-	return ( ! empty( $meta ) ) ? explode( ',', $meta ) : false;
+	return ( ! empty( $meta ) ) ? explode( ',', $meta ) : array();
 }
 
 


### PR DESCRIPTION
Function should return an arry, not a boolean

Fix for #855 

Question would be if any code that uses this function depends on a boolean to be returned instead of an empty array. 
E.g. 
`if ( $attachment_ids ) foreach ( $attachment_ids as $attachment_id )`
Would be fine, but if statement is now obsolete. 
`if( !empty( $attachment_ids ) )` and `$attachment_id = ! empty( $attachment_id ) ? $attachment_id[0] : $post_id;` already expected an element that can be empty.

And then there are several places, where it did not check at all on false or empty and these should be fine with an empty array.
