### PR TITLE
change link location in Class Layouts

### DIFF
--- a/inc/class-layouts.php
+++ b/inc/class-layouts.php
@@ -335,7 +335,7 @@ class SellMediaLayouts {
 
 		$html  = '<div id="sell-media-' . $original_id . '" class="' . $class . '">';
 
-		$html .= '<a href="' . esc_url( get_permalink( $original_id ) ) . '" ' . sell_media_link_attributes( $original_id ) . ' class="sell-media-item">';
+		$html .= '<a href="' . esc_url( get_permalink( $post_id ) ) . '" ' . sell_media_link_attributes( $post_id ) . ' class="sell-media-item">';
 
 		// Show titles?
 		if ( isset( $this->settings->titles ) && 0 != $this->settings->titles && is_main_query() ) {


### PR DESCRIPTION
change link to the post_id instead of original_id so that the thumbnail links to the sell media item instead of the attachment on keyword archive pages.  

(post_id gets set to the sell_media_item if the original was an attachment, original_id is not updated so it was linking straight to the attachment url instead of the sell media item)